### PR TITLE
Add utilities for committing pending bits

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -83,6 +83,9 @@ func (w *Writer) Commit() (written int, err error) {
 // If it is unknown if the number of bits written will completely fill all
 // chunks, then it is recommended to execute this once to conclude writing.
 func (w *Writer) CommitPending() (written int, err error) {
+	if w.HasPendingBits() {
+		return w.Commit()
+	}
 	return
 }
 

--- a/writer.go
+++ b/writer.go
@@ -72,6 +72,7 @@ func (w *Writer) Commit() (written int, err error) {
 	written, err = w.w.Write(w.bytes)
 	written *= byteSize
 	w.bytes = make([]byte, len(w.bytes))
+	w.index = 0
 	return
 }
 

--- a/writer.go
+++ b/writer.go
@@ -90,7 +90,7 @@ func (w *Writer) CommitPending() (written int, err error) {
 // not yet been written to the underlying writer. For example, if half of a
 // byte is written, then there are 4 pending bits.
 func (w Writer) HasPendingBits() bool {
-	return false
+	return w.index != 0
 }
 
 // ByteIndex gets the index of the current byte to write bits to.

--- a/writer.go
+++ b/writer.go
@@ -64,8 +64,7 @@ func (w *Writer) WriteBits(bits Bits, length int) (written int, err error) {
 
 // Commit commits the current bytes to the writer, even if a byte is only
 // partially written. Partial bytes will be zero-filled. A commit will happen
-// any time that a write would overflow the current chunk. A single commit when
-// writing is finished is recommended.
+// any time that a write would overflow the current chunk.
 //
 // The number of bits written are returned, and any error that occurred when
 // writing.
@@ -74,6 +73,23 @@ func (w *Writer) Commit() (written int, err error) {
 	written *= byteSize
 	w.bytes = make([]byte, len(w.bytes))
 	return
+}
+
+// CommitPending is a helper function that commits the current written bits
+// only if the byte chunk is partially written. Does nothing if the byte chunk
+// is empty.
+//
+// If it is unknown if the number of bits written will completely fill all
+// chunks, then it is recommended to execute this once to conclude writing.
+func (w *Writer) CommitPending() (written int, err error) {
+	return
+}
+
+// HasPendingBits returns true if there are any bits that are pending, but have
+// not yet been written to the underlying writer. For example, if half of a
+// byte is written, then there are 4 pending bits.
+func (w Writer) HasPendingBits() bool {
+	return false
 }
 
 // ByteIndex gets the index of the current byte to write bits to.

--- a/writer_test.go
+++ b/writer_test.go
@@ -130,7 +130,7 @@ func TestCommitPending(t *testing.T) {
 		wantByte    byte
 	}{
 		{0xA, 4, 8, 0xA0},
-		{0xA0, 8, 0, 0xAB},
+		{0xA0, 8, 0, 0xA0},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Adds utilities to help the user commit bits *if they are pending*.

This can help avoid mistakes by executing an extra "commit".
